### PR TITLE
fix: python attribute error for urllib

### DIFF
--- a/speedapp.py
+++ b/speedapp.py
@@ -4,7 +4,7 @@
 import json
 import re
 import time
-import urllib
+import urllib.request
 import os
 import logging
 from base64 import urlsafe_b64decode


### PR DESCRIPTION
Fixes error `An error occurred: module 'urllib' has no attribute 'request'` on python 3